### PR TITLE
NOT TESTED FIX: IDA GUI FIX

### DIFF
--- a/src/host/ida/ui/decompiler_form.py
+++ b/src/host/ida/ui/decompiler_form.py
@@ -69,7 +69,9 @@ class DecompilerForm(idaapi.PluginForm):
     for phase in decompilation_phase:
       self.phase_selection.addItem(phase)
 
-    self.phase_selection.setCurrentIndex(decompiler.STEP_DECOMPILED)
+    # case sensitive for step_decompiled and setCurrentIndex argument should be integer,
+    # so why not just (0)???
+    self.phase_selection.setCurrentIndex(0)
     self.phase_selection.currentIndexChanged.connect(self.phase_selected)
 
     self.parent.setLayout(layout)
@@ -80,12 +82,15 @@ class DecompilerForm(idaapi.PluginForm):
     self.decompile(index)
     return
 
-  def decompile(self, wanted_step=decompiler.STEP_DECOMPILED):
+  def decompile(self, wanted_step=None):
+
+    if not wanted_step:
+      wanted_step = decompiler.step_decompiled
 
     dis = host.dis.available_disassemblers['ida'].create()
     d = decompiler.decompiler_t(dis, self.ea)
 
-    for step in d.steps():
+    for step in d.STEPS():
       print 'Decompiler step: %u - %s' % (step, decompilation_phase[step])
       if step >= wanted_step:
         break


### PR DESCRIPTION
There is nothing called `STEP_DECOMPILED` and calling it in decompile argument was throwing error, this is a small workaround to fix it :).
For `for step in d.steps():` is that correct? decompiler_t have `STEPS` instead.
